### PR TITLE
Add post detail page

### DIFF
--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -49,3 +49,21 @@ export const getPostEachUser = async (uid: string | string[] | UserAuthContextTy
     });
     return postsDataList;
 };
+
+//詳細を見るボタンを押された求人を取得
+export const getPostDetail = async (id: string) => {
+    const postData = await db.collection("posts").doc(id).get();
+
+    return postData;
+};
+
+//各投稿詳細ページのパスを生成
+export const createPostPagePath = async (uid: string) => {
+    let dataList = [];
+    const postId = await db.collection("posts").where("uid", "==", `${uid}`).get();
+    postId.forEach((data) => {
+        dataList.push(data.id);
+    });
+
+    return dataList;
+};

--- a/src/components/atoms/DetailButton.tsx
+++ b/src/components/atoms/DetailButton.tsx
@@ -1,17 +1,24 @@
 import React from "react";
+import { useRouter } from "next/router";
+
+//apis
+import { createPostPagePath } from "@apis/post";
 
 type Props = {
     text: string;
+    uid: string;
 };
 
 export const DetailButton: React.FC<Props> = (props) => {
-    const { text } = props;
+    const { text, uid } = props;
+    const router = useRouter();
 
     return (
         <>
             <button
-                onClick={() => {
-                    alert("申し訳ありません🙇‍♂️ 詳細ページは現在作成中です。");
+                onClick={async () => {
+                    const dataList = await createPostPagePath(uid);
+                    router.push(`/post/${dataList}`);
                 }}
                 className="btn btn-accent inline-block w-full"
             >

--- a/src/components/molecules/PostCard.tsx
+++ b/src/components/molecules/PostCard.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-import Image from "next/image";
-// import Image from "next/image";
 
 //components
 import { DetailButton } from "@components/atoms/DetailButton";
@@ -19,14 +17,6 @@ export const PostCard: React.FC<Props> = (props) => {
         <>
             <div className="w-11/12 rounded-3xl bg-white border border-gray-300 p-6 mx-auto">
                 <div className="">
-                    {/* <div className="rounded-full text-center mx-auto">
-                        <Image
-                            src={userPostData.post_img}
-                            width={1000}
-                            height={1000}
-                            alt="プロフィール画像"
-                        />
-                    </div> */}
                     <div className="mb-4 mt-4 lg:flex lg:flex-col lg:text-left lg:mb-8  xl:mr-0">
                         <h2 className="text-2xl font-semibold mb-2 mx-auto lg:text-3xl lg:inline-block lg:mx-0 ">
                             {userPostData.title}
@@ -45,7 +35,7 @@ export const PostCard: React.FC<Props> = (props) => {
                             </p>
                         </div>
                         <div className="w-4/5 mx-auto md:w-3/5 lg lg:w-2/5">
-                            <DetailButton text={"詳細を見る"} />
+                            <DetailButton text={"詳細を見る"} uid={userPostData.uid} />
                         </div>
                     </div>
                 </div>

--- a/src/components/templates/PostPageTemplate.tsx
+++ b/src/components/templates/PostPageTemplate.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import Image from "next/image";
+
+//components
+import { BaseLayout } from "@components/layouts/BaseLayout";
+
+//types
+import { PostDataType } from "src/types/post/PostDataType";
+import { UserDataType } from "src/types/user/UserDataType";
+
+type Props = {
+    userData: UserDataType;
+    postData: PostDataType;
+};
+
+export const PostPageTemplate: React.FC<Props> = (props) => {
+    const { userData, postData } = props;
+
+    return (
+        <>
+            <BaseLayout>
+                <main className="w-full min-h-screen mt-16 pt-6  bg-white lg:mt-20 lg:w-3/5 lg:mx-auto">
+                    <h1 className="mb-4 p-4 text-2xl font-bold text-center text-green-400 md:text-3xl lg:text-4xl">
+                        {postData.title}
+                    </h1>
+                    <p className="w-11/12 font-bold mb-2 text-right text- text-xs md:text-xl">{`投稿者連絡先: ${userData.user_email.slice(
+                        0,
+                        21,
+                    )}`}</p>
+                    <div>
+                        <Image
+                            src={postData.post_img}
+                            width={1000}
+                            height={1000}
+                            alt={"求人詳細イメージ画像"}
+                        />
+                    </div>
+                    <div className="w-11/12 mx-auto">
+                        <p className="text-xs text-center mx-auto p-2 rounded-full inline-block text-white mb-4 bg-background-sub lg:text-xs lg:mb-6">
+                            {postData.category}
+                        </p>
+                        <div className="flex justify-between mb-4 md:mb-6">
+                            <p className="text-sm lg:text-lg">{`時給: ${postData.salary}`}</p>
+                            <span className="block text-xs text-gray-500 lg:text-sm">{`投稿日: ${postData.created_at}`}</span>
+                        </div>
+                        <h2 className="my-6 text-xl font-semibold lg:my-12 lg:text-3xl">
+                            ---求人詳細---
+                        </h2>
+                        {postData.body
+                            .split(/(\n)/g)
+                            .map((text, index) => (text === "\n" ? <br key={index} /> : text))}
+                    </div>
+                    <div className="mt-12 p-8 bg-background-main lg:pb-12">
+                        <h2 className="my-6 font-bold lg:text-2xl text-green-400">
+                            投稿者プロフィール
+                        </h2>
+                        <div className="lg;flex lg:justify-between">
+                            <div className="my-4 text-center">
+                                <Image
+                                    src={userData.user_img}
+                                    width={180}
+                                    height={180}
+                                    alt={"ユーザー画像"}
+                                    className="rounded-full"
+                                />
+                            </div>
+                            <div>
+                                <p className="font-bold text-xl lg:text-2xl">{`氏名: ${userData.user_name}`}</p>
+                                <p className="my-4">
+                                    所属: {`${userData.user_subject}学科 ${userData.user_grade}`}
+                                </p>
+                                <p>{userData.created_at}に登録したユーザー</p>
+                            </div>
+                        </div>
+                    </div>
+                </main>
+            </BaseLayout>
+        </>
+    );
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,7 @@ import type { NextPage } from "next";
 import { useRouter } from "next/router";
 
 //apis
-import { getAllPostsData } from "src/apis/post";
+import { getAllPostsData } from "@apis/post";
 
 //libs
 import { auth } from "@libs/firebaseConfig";

--- a/src/pages/post/[id].tsx
+++ b/src/pages/post/[id].tsx
@@ -1,0 +1,45 @@
+import type { NextPage } from "next";
+import Head from "next/head";
+
+//apis
+import { getUserProfileData } from "@apis/user";
+import { getPostDetail } from "@apis/post";
+
+//components
+import { PostPageTemplate } from "@components/templates/PostPageTemplate";
+
+//types
+import { GetServerSideProps } from "next";
+import { UserDataType } from "src/types/user/UserDataType";
+import { PostDataType } from "src/types/post/PostDataType";
+
+type Props = {
+    userData: UserDataType;
+    postData: PostDataType;
+};
+
+const user: NextPage<Props> = (props) => {
+    const { userData, postData } = props;
+
+    return (
+        <>
+            <Head>
+                <title>{postData.title}</title>
+            </Head>
+
+            <PostPageTemplate userData={userData} postData={postData} />
+        </>
+    );
+};
+
+export default user;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    const { id } = context.params;
+
+    let postData = (await getPostDetail(id as string)).data();
+    postData.created_at = postData.created_at.toDate().toLocaleDateString();
+    const userData = await getUserProfileData(postData.uid);
+
+    return { props: { userData: userData, postData: postData } };
+};

--- a/src/pages/user/[uid].tsx
+++ b/src/pages/user/[uid].tsx
@@ -2,8 +2,8 @@ import type { NextPage } from "next";
 import Head from "next/head";
 
 //apis
-import { getPostEachUser } from "src/apis/post";
-import { getUserProfileData } from "src/apis/user";
+import { getPostEachUser } from "@apis/post";
+import { getUserProfileData } from "@apis/user";
 
 //components
 import { UserPageTemplate } from "@components/templates/UserPageTemplate";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
         "jsx": "preserve",
         "baseUrl": ".",
         "paths": {
+            "@apis/*": ["src/apis/*"],
             "@components/*": ["src/components/*"],
             "@libs/*": ["src/libs/*"],
             "@styles/*": ["styles/*"],


### PR DESCRIPTION
## 求人投稿詳細ページの作成
### 実装内容
* 各投稿コンポーネントが持つ詳細ボタンがクリックされたら、その投稿の一意のidをfirestoreから取得して、パスを生成し、routerを使ってページ遷移
* 詳細ページのデザイン・レイアウトを作成