### PR TITLE
ブックマーク機能の修正

### DIFF
--- a/src/apis/bookmark.ts
+++ b/src/apis/bookmark.ts
@@ -1,21 +1,28 @@
 //libs
-import { db } from "@libs/firebaseConfig";
+import firebase, { db } from "@libs/firebaseConfig";
 
 //types
 import { PostDataType } from "src/types/post/PostDataType";
 
 //ブックマークリストに求人投稿を追加
 export const addPostToBookmarkList = async (uid: string, postData: PostDataType) => {
-    const bookmarkedRef = db
+    await db
         .collection("users")
         .doc(`${uid}`)
-        .collection("bookmarks")
-        .doc(postData.postID);
-    await bookmarkedRef.set(postData);
+        .set(
+            {
+                bookmarks: [postData.postID],
+            },
+            { merge: true },
+        );
 };
 
 //リストから削除
 export const deletePostToBookmarkList = async (uid: string, id: string) => {
-    const bookmarkedRef = db.collection("users").doc(`${uid}`).collection("bookmarks").doc(`${id}`);
-    await bookmarkedRef.delete();
+    await db
+        .collection("users")
+        .doc(`${uid}`)
+        .update({
+            bookmarks: firebase.firestore.FieldValue.arrayRemove(`${id}`),
+        });
 };

--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -103,12 +103,14 @@ export const getBookmarkedPosts = async (uid: string | string[]) => {
     let bookmarkedDataList = [];
     const userData = (await db.collection("users").doc(`${uid}`).get()).data();
 
-    for (const postID of userData.bookmarks) {
-        const resultDoc = await db.collection("posts").doc(`${postID}`).get();
-        const result = resultDoc.data();
-        result.postID = resultDoc.id;
-        result.created_at = result.created_at.toDate().toLocaleDateString();
-        bookmarkedDataList.push(result);
+    if (userData.bookmarks) {
+        for (const postID of userData.bookmarks) {
+            const resultDoc = await db.collection("posts").doc(`${postID}`).get();
+            const result = resultDoc.data();
+            result.postID = resultDoc.id;
+            result.created_at = result.created_at.toDate().toLocaleDateString();
+            bookmarkedDataList.push(result);
+        }
     }
 
     return bookmarkedDataList;

--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -101,13 +101,15 @@ export const getPostsDataByCategory = async (categoryID: string) => {
 //ブックマークされた求人投稿を取得
 export const getBookmarkedPosts = async (uid: string | string[]) => {
     let bookmarkedDataList = [];
-    const bookmarkedData = await db.collection("users").doc(`${uid}`).collection("bookmarks").get();
+    const userData = (await db.collection("users").doc(`${uid}`).get()).data();
 
-    bookmarkedData.forEach((postData) => {
-        const result = postData.data();
-
+    for (const postID of userData.bookmarks) {
+        const resultDoc = await db.collection("posts").doc(`${postID}`).get();
+        const result = resultDoc.data();
+        result.postID = resultDoc.id;
+        result.created_at = result.created_at.toDate().toLocaleDateString();
         bookmarkedDataList.push(result);
-    });
+    }
 
     return bookmarkedDataList;
 };

--- a/src/components/atoms/comments/ReplyComment.tsx
+++ b/src/components/atoms/comments/ReplyComment.tsx
@@ -5,9 +5,6 @@ import Image from "next/image";
 import { CommentDataType } from "src/types/comment/CommentDataType";
 import { UserDataType } from "src/types/user/UserDataType";
 
-//utils
-import { convertDateStr } from "src/utils/convertDateStr";
-
 type Props = {
     comment: CommentDataType;
     userData: UserDataType;
@@ -32,7 +29,7 @@ export const ReplyComment: React.FC<Props> = (props) => {
                     <div className="flex justify-between">
                         <p className="font-semibold">{userData.user_name}</p>
                         <span className="text-gray-500 text-sm ml-8">
-                            {`${convertDateStr(comment.created_at)}`}
+                            {`${comment.created_at}`}
                         </span>
                     </div>
                     <p className="mt-2 text-sm">{comment.comment}</p>

--- a/src/components/atoms/icons/BookmarkedIcon.tsx
+++ b/src/components/atoms/icons/BookmarkedIcon.tsx
@@ -30,18 +30,14 @@ export const BookmarkedIcon: React.FC<Props> = (props) => {
             <div className="dropdown dropdown-end">
                 <BsFillBookmarkHeartFill
                     tabIndex={0}
-                    className="w-6 h-6 mr-3 lg:w-10 lg:h-10 hover:cursor-pointer text-pink-400 hover:text-pink-700 lg:mr-4"
+                    className="w-6 h-6 mr-3 lg:w-10 lg:h-10 hover:cursor-pointer text-pink-400 hover:text-pink-200 lg:mr-4"
                     onClick={async () => {
-                        let list = [];
-                        const bookmarkData = await db
-                            .collection("users")
-                            .doc(`${User.uid}`)
-                            .collection("bookmarks")
-                            .get();
-                        bookmarkData.forEach((data) => {
-                            list.push(data.id);
-                            const isPostID = list.find((postID) => postID === userPostData.postID);
-                            if (isPostID) {
+                        const userData = (
+                            await db.collection("users").doc(`${User.uid}`).get()
+                        ).data();
+
+                        userData.bookmarks.forEach((postID) => {
+                            if (postID === userPostData.postID) {
                                 setIsBookmarked(true);
                             }
                         });

--- a/src/components/atoms/icons/BookmarkedIcon.tsx
+++ b/src/components/atoms/icons/BookmarkedIcon.tsx
@@ -36,11 +36,13 @@ export const BookmarkedIcon: React.FC<Props> = (props) => {
                             await db.collection("users").doc(`${User.uid}`).get()
                         ).data();
 
-                        userData.bookmarks.forEach((postID) => {
-                            if (postID === userPostData.postID) {
-                                setIsBookmarked(true);
-                            }
-                        });
+                        if (userData.bookmarks) {
+                            userData.bookmarks.forEach((postID: string) => {
+                                if (postID === userPostData.postID) {
+                                    setIsBookmarked(true);
+                                }
+                            });
+                        }
                     }}
                 />
                 <div


### PR DESCRIPTION
## 修正内容
* ブックマークした投稿の保存場所を変更
Firestoreの各ユーザードキュメントのサブコレクション　→ 　各ユーザーのbookmarkフィールドを新たに追加し、リスト形式で保存

* 保存データを修正
求人投稿の全てのデータ　→  投稿の一意ID（postID)

## 修正による効果
* リストでデータを持つことによって、データ読み取り回数を削減
* 投稿者が投稿を削除した場合、SSGの再生成が実行されなくなり、投稿データが完全に削除される。これによって、全ユーザー間のデータの整合性が担保される。